### PR TITLE
Potential fix for code scanning alert no. 185: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/vulnerability-comparison.yml
+++ b/.github/workflows/vulnerability-comparison.yml
@@ -1,4 +1,6 @@
 name: Vulnerability comparison
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/brabster/terraform-bootstrap-gcp/security/code-scanning/185](https://github.com/brabster/terraform-bootstrap-gcp/security/code-scanning/185)

To address this issue, add an explicit `permissions` block to the workflow, granting only the minimal privileges necessary for its execution.  
Based on the workflow’s steps, it does not require write access to any resources (repository contents, issues, pull-requests), as it simply checks out the repository, scans container images, uploads/downloads artifacts, and generates a report. All these can be done with `contents: read`. Therefore, add a `permissions` block to the root of the workflow, specifying `contents: read`. This will apply to all jobs unless a job-level override is set, and is placed immediately after the `name` and before `on:`.

No additional dependencies, imports, or definitions are required—just an update to the workflow YAML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
