### PR TITLE
need ca-certificates to install terraform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [TBD] - Refactor Dockerfile to multi-stage build to remediate OS-level vulnerabilities
+## [[#63](https://github.com/brabster/terraform-bootstrap-gcp/pull/63)] - Add ca-certificates package for Terraform installation
+
+### Added
+
+- Added ca-certificates package (Canonical) to Dockerfile apt-get install command and documented it in inline comments.
+
+### Rationale
+
+The ca-certificates package is required for HTTPS certificate validation during the Terraform installation process. Without it, the apt_install_thirdparty.sh script fails when downloading GPG keys and configuring third-party apt repositories over HTTPS. This package provides the system-wide certificate trust store containing Mozilla's CA certificate bundle.
+
+### Security
+
+- Fixed build failures when installing Terraform due to missing HTTPS certificate validation capabilities.
+- Added explicit dependency on Canonical's certificate trust store for HTTPS operations.
+
+  - **Supply Chain Posture Impact:** Makes an implicit dependency explicit, improving transparency. The Terraform installation required HTTPS certificate validation but was failing without ca-certificates. By explicitly installing and documenting this package, we clarify our reliance on Canonical's Mozilla CA certificate bundle for trust decisions in all HTTPS operations during the build process. The package receives regular security updates through Ubuntu.
+  - **Security Posture Impact:** Positive
+
+## [[#61](https://github.com/brabster/terraform-bootstrap-gcp/pull/61)] - Refactor Dockerfile to multi-stage build to remediate OS-level vulnerabilities
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ LABEL org.opencontainers.image.licenses="MIT"
 
 COPY scripts/ /tmp/scripts/
 
-# Install third party software, git (Canonical) and bash-completion (Canonical) for git CLI completion
+# Install third party software, git (Canonical), bash-completion (Canonical), and ca-certificates (Canonical) for HTTPS certificate validation
 # Install proxy certificate if provided (for environments with intercepting proxies)
 # Delete bundled python from gcloud (removed cryptography vulnerability, reduces image size)
 # Remove build-only packages (gnupg, lsb-release, wget) and unnecessary utilities (unminimize) after use to reduce attack surface

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN --mount=type=secret,id=proxy_cert,required=false \
     && /tmp/scripts/install_proxy_cert.sh "$([ -f /run/secrets/proxy_cert ] && echo /run/secrets/proxy_cert || echo '')" \
     && apt-get update \
     && apt-get -y upgrade \
-    && apt-get install -y --no-install-recommends gnupg lsb-release wget bash-completion git python3 \
+    && apt-get install -y --no-install-recommends gnupg lsb-release wget bash-completion git python3 ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
     && /tmp/scripts/apt_install_thirdparty.sh "https://apt.releases.hashicorp.com/gpg" "terraform" "https://apt.releases.hashicorp.com $(lsb_release -cs) main" \
     && /tmp/scripts/apt_install_thirdparty.sh "https://packages.cloud.google.com/apt/doc/apt-key.gpg" "google-cloud-cli" "https://packages.cloud.google.com/apt cloud-sdk main" \


### PR DESCRIPTION
Must've been installed as a transitive of something we've stripped out
